### PR TITLE
Fix: SDK Conflict with Vuforia 9.8.8 [issue #10]

### DIFF
--- a/Plugins/iOS/zappar-unity.h
+++ b/Plugins/iOS/zappar-unity.h
@@ -6,8 +6,8 @@
 
 #define ZAPPAR_METAL_SUPPORT // Comment out this line if you _do not_ want to include support for Metal. 
 
-extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces);
-extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload();
+extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API ZAPUnityPluginLoad(IUnityInterfaces* unityInterfaces);
+extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API ZAPUnityPluginUnload();
 
 static void UNITY_INTERFACE_API OnNativeGLRenderEvent(int eventID);
 extern "C" UnityRenderingEvent UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API zappar_upload_callback_native_gl();

--- a/Plugins/iOS/zappar-unity.mm
+++ b/Plugins/iOS/zappar-unity.mm
@@ -7,8 +7,8 @@ static id<MTLDevice> s_device = 0;
 static IUnityInterfaces* s_interface = 0;
 static zappar_pipeline_t s_pipeline = 0;
 
-extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload() {}
-extern "C" void	UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces)
+extern "C" void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API ZAPUnityPluginUnload() {}
+extern "C" void	UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API ZAPUnityPluginLoad(IUnityInterfaces* unityInterfaces)
 {
     s_interface = unityInterfaces;
 
@@ -72,7 +72,7 @@ extern "C" void* zappar_pipeline_camera_frame_texture_dx11(zappar_pipeline_t o) 
 @implementation Zappar_iOSPluginController
 - (void)shouldAttachRenderDelegate
 {
-    UnityRegisterRenderingPluginV5(&UnityPluginLoad, &UnityPluginUnload);
+    UnityRegisterRenderingPluginV5(&ZAPUnityPluginLoad, &ZAPUnityPluginUnload);
     id rootViewController = UnityGetGLViewController();
     zappar_ios_uiviewcontroller_set( rootViewController );
 }


### PR DESCRIPTION
With this changes you will avoid issue connected with other SDK's
In my case it was Vuforia, which has same UnityPluginLoad and Unload function name compared with Zappar SDK.
So to be Unique and avoid conflicts, you should have different name for your 'activity'